### PR TITLE
Set read mode to 'rt' for non gz files.

### DIFF
--- a/basta/DBUtils.py
+++ b/basta/DBUtils.py
@@ -52,7 +52,7 @@ def create_db(path,f,of,i1,i2):
 
     timetotal = 0
     try:
-        with (gzip.open(ip,"rt") if ip.endswith(".gz") else open(ip,"r")) as f:
+        with (gzip.open(ip,"rt") if ip.endswith(".gz") else open(ip,"rt")) as f:
             start_time = timeit.default_timer()
             for count,line in enumerate(f):
                 if not count % 1000000:


### PR DESCRIPTION
Pretty easy fix. See error below:

```shell
$ basta taxonomy -d $BASTADB

#### Downloading and processing NCBI taxonomy files


# [BASTA STATUS] Download taxonomy files

# [BASTA STATUS] (Re-)Downloading file taxdump.tar.gz

--2022-10-21 02:25:21--  ftp://ftp.ncbi.nih.gov/pub/taxonomy//taxdump.tar.gz
           => ‘/nfs1/CGRB/databases/BASTA/latest/taxdump.tar.gz’
Resolving ftp.ncbi.nih.gov (ftp.ncbi.nih.gov)... 130.14.250.10, 130.14.250.12, 2607:f220:41e:250::13, ...
Connecting to ftp.ncbi.nih.gov (ftp.ncbi.nih.gov)|130.14.250.10|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /pub/taxonomy/ ... done.
==> SIZE taxdump.tar.gz ... 59126229
==> PASV ... done.    ==> RETR taxdump.tar.gz ... done.
Length: 59126229 (56M) (unauthoritative)

100%[=================================================================================================================>] 59,126,229  28.1MB/s   in 2.0s

2022-10-21 02:25:24 (28.1 MB/s) - ‘/nfs1/CGRB/databases/BASTA/latest/taxdump.tar.gz’ saved [59126229]


# [BASTA STATUS] (Re-)Downloading file taxdump.tar.gz.md5

--2022-10-21 02:25:24--  ftp://ftp.ncbi.nih.gov/pub/taxonomy//taxdump.tar.gz.md5
           => ‘/nfs1/CGRB/databases/BASTA/latest/taxdump.tar.gz.md5’
Resolving ftp.ncbi.nih.gov (ftp.ncbi.nih.gov)... 130.14.250.12, 130.14.250.10, 2607:f220:41e:250::11, ...
Connecting to ftp.ncbi.nih.gov (ftp.ncbi.nih.gov)|130.14.250.12|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /pub/taxonomy/ ... done.
==> SIZE taxdump.tar.gz.md5 ... 49
==> PASV ... done.    ==> RETR taxdump.tar.gz.md5 ... done.
Length: 49 (unauthoritative)

100%[=================================================================================================================>] 49          --.-K/s   in 0s

2022-10-21 02:25:25 (3.63 MB/s) - ‘/nfs1/CGRB/databases/BASTA/latest/taxdump.tar.gz.md5’ saved [49]


# [BASTA STATUS] Checking MD5 sum of file

citations.dmp
delnodes.dmp
division.dmp
gencode.dmp
merged.dmp
names.dmp
nodes.dmp
gc.prt
readme.txt

# [BASTA STATUS] Creating complete taxonomy file


# [BASTA STATUS] Creating taxonomy database

# [BASTA STATUS] Reading mapping file
This might take a while, please be patient ...

Traceback (most recent call last):
  File "/local/cluster/BASTA-1.4.1/bin/basta", line 4, in <module>
    __import__('pkg_resources').run_script('BASTA==1.4', 'basta')
  File "/local/cluster/BASTA-1.4.1/lib/python3.10/site-packages/pkg_resources/__init__.py", line 672, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/local/cluster/BASTA-1.4.1/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1472, in run_script
    exec(code, namespace, namespace)
  File "/local/cluster/BASTA-1.4.1/lib/python3.10/site-packages/BASTA-1.4-py3.10.egg/EGG-INFO/scripts/basta", line 118, in <module>
    main.run_basta(args)
  File "/local/cluster/BASTA-1.4.1/lib/python3.10/site-packages/BASTA-1.4-py3.10.egg/basta/BastaMain.py", line 89, in run_basta
    self._basta_taxonomy(args)
  File "/local/cluster/BASTA-1.4.1/lib/python3.10/site-packages/BASTA-1.4-py3.10.egg/basta/BastaMain.py", line 194, in _basta_taxonomy
    dbutils.create_db(args.directory,"complete_taxa.gz","complete_taxa.db",0,1)
  File "/local/cluster/BASTA-1.4.1/lib/python3.10/site-packages/BASTA-1.4-py3.10.egg/basta/DBUtils.py", line 66, in create_db
    ls = line.strip("\n").split("\t")
TypeError: a bytes-like object is required, not 'str'
basta taxonomy -d $BASTADB  70.99s user 9.54s system 94% cpu 1:25.36 total
```

After fixing and rerunning:

```shell
$ basta taxonomy -d $BASTADB
...
# [BASTA STATUS] Reading mapping file
This might take a while, please be patient ...


# [BASTA STATUS] 1000000 lines processed (avg time: 15.245395sec)

# [BASTA STATUS] 2000000 lines processed (avg time: 18.204847sec)

### Done! NCBI taxonomy database created in /nfs1/CGRB/databases/BASTA/latest ####
```